### PR TITLE
Fix app_lifespan function signature to accept app parameter

### DIFF
--- a/gmail_mcp.py
+++ b/gmail_mcp.py
@@ -40,7 +40,7 @@ class ResponseFormat(str, Enum):
 
 # Lifespan management for persistent HTTP client
 @asynccontextmanager
-async def app_lifespan():
+async def app_lifespan(app):
     """Manage HTTP client lifecycle."""
     client = httpx.AsyncClient(timeout=30.0)
     yield {"http_client": client}


### PR DESCRIPTION
Fixed TypeError: app_lifespan() takes 0 positional arguments but 1 was given The FastMCP framework passes an app parameter to the lifespan function.