### PR TITLE
Add Docker CLI to bridge container

### DIFF
--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -2,14 +2,17 @@ FROM node:18-alpine
 
 WORKDIR /app
 
-# Install dependencies
+# Install Docker CLI so we can exec into other containers
+RUN apk add --no-cache docker-cli
+
+# Install Node.js dependencies
 RUN npm install express cors
 
 # Copy bridge server
 COPY bridge-server.js .
 
 # Expose port
-EXPOSE 3001
+EXPOSE 3002
 
 # Run the bridge server
 CMD ["node", "bridge-server.js"]


### PR DESCRIPTION
Install docker-cli in the Node.js Alpine container so the bridge can execute 'docker exec' commands to communicate with the gmail-mcp-server container.

Also fixed port from 3001 to 3002.

This fixes the '/bin/sh: docker: not found' error.