### PR TITLE
Fix JSON escaping for email bodies with newlines

### DIFF
--- a/bridge-server.js
+++ b/bridge-server.js
@@ -81,7 +81,12 @@ app.post('/v1/tools/execute', async (req, res) => {
 
 // Build the Docker exec command based on tool name and arguments
 function buildMCPCommand(toolName, args) {
-  const argsJson = JSON.stringify(args || {}).replace(/"/g, '\\"');
+  // Properly escape JSON for embedding in Python single-quoted string
+  const argsJson = JSON.stringify(args || {})
+    .replace(/\\/g, '\\\\')  // Escape backslashes first (\ -> \\)
+    .replace(/'/g, "\\'");    // Escape single quotes (' -> \')
+
+  // Note: We use single quotes in Python, so we escape single quotes not double quotes
 
   // Strip "gmail/" prefix if present
   const cleanToolName = toolName.replace(/^gmail\//, '');


### PR DESCRIPTION
The previous escaping only replaced double quotes, which caused JSONDecodeError when email bodies contained newlines or other special characters.

Issue: When JSON.stringify creates {"body":"line1\nline2"}, the \n was being interpreted as a literal newline by Python's string parser, breaking the JSON.

Fix: Properly escape backslashes (\ -> \\) and single quotes (' -> \') so Python preserves the escape sequences for json.loads to parse.

This fixes the error:
  JSONDecodeError: Invalid control character at line 1, column 78

Now emails with multi-line bodies (like haikus) work correctly.